### PR TITLE
Mac OS X should be detected as Linux, fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var Async = require("async"),
 var LIB = Path.join(__dirname, "lib"),
 	COMMANDS;
 
-if (require("os").type() === "Linux") {
+var osType = require("os").type();
+if (osType === "Linux" || osType === "Darwin") {
 	COMMANDS = require(Path.join(LIB, "linux"));
 } else {
 	COMMANDS = require(Path.join(LIB, "windows"));


### PR DESCRIPTION
This package on Mac works as Linux, and def. does not as Windows
